### PR TITLE
Use Ecosia as Default Search Provider in Chrome

### DIFF
--- a/os2borgerpc/chrome/chrome_install.sh
+++ b/os2borgerpc/chrome/chrome_install.sh
@@ -34,6 +34,13 @@
 # RestoreOnStartup: Controls what happens on startup. Also prevents users from changing the startup URLs when reopening the browser without logging out of the OS first. Possibly not needed with Guest mode, incognito or ephemeral.
 # RestoreOnStartupURLs: This is, confusingly, what can actually control the homepage, but only if RestoreOnStartup is set to "4".
 #
+# Search:
+# DefaultSearchProviderEnabled: Default search is performed when a user enters non-URL text in the address bar. The default search provider can not be changed by a user.
+# DefaultSearchProviderIconURL: Specifies the default search provider's favorite icon URL.
+# DefaultSearchProviderName: Specifies the default search provider's name.
+# DefaultSearchProviderSearchURL: Specifies the URL of the search provider used during a default search.
+# DefaultSearchProviderSuggestURL: Specifies the URL of the search provider to provide search suggestions.
+# 
 # Various:
 # BrowserGuestModeEnabled: Allow people to start a guest session, if they want, so history isn't even temporarily recorded. Not crucial.
 # BrowsingDataLifetime: Continuously remove all browsing data after 1 hour (the minimum possible),
@@ -131,6 +138,11 @@ cat > "$POLICY" <<- END
       }
     ],
     "DefaultBrowserSettingEnabled": false,
+    "DefaultSearchProviderEnabled": true,
+    "DefaultSearchProviderIconURL": "https://cdn-static.ecosia.org/static/icons/favicon.ico",
+    "DefaultSearchProviderName": "Ecosia",
+    "DefaultSearchProviderSearchURL": "https://ecosia.org/search?q={searchTerms}",
+    "DefaultSearchProviderSuggestURL": "https://ac.ecosia.org/autocomplete?q={searchTerms}&type=list",
     "DeveloperToolsAvailability": 2,
     "EnableMediaRouter": false,
     "ExtensionInstallBlocklist": [

--- a/os2borgerpc/chrome/chrome_install.sh
+++ b/os2borgerpc/chrome/chrome_install.sh
@@ -6,6 +6,7 @@
 #    - prevents Google Chrome from asking if it should be default browser and about browser metrics
 #    - prevents the user logging in to the browser
 #    - disables the remember password prompt feature.
+#    - configures Ecosia as the Default Search Provider 
 # 3. Add a launch option to Chrome that prevents it
 #    from checking for updates and showing it's out of date to whoever
 


### PR DESCRIPTION
## What
This PR changes the Chrome policy in `chrome_install.sh` to configure [Ecosia ](https://www.ecosia.org) as the Default Search Provider. The Default Search Provider is the search engine that is used when you enter non-URL text in the address bar.

## Why
Right now, if a citizen for example searches "iPhone" on an OS2borgerPC, advertisement revenue goes directly into Google's pockets. Neither you, I, nor the municipalities benefit from this. Ecosia — the search engine that plants trees — use 80% of its profits to support tree-planting projects, and on average it only takes 45 searches to plant a tree. Imagine how many trees our citizens can plant each and every day by searching the web with Ecosia on OS2borgerPCs. This small PR can make a huge impact! Ecosia does not sell personal data to advertisers and has full financial transparency.

Remember, to solve the climate crisis, we cannot stay satisfied with status quo — we need climate action on all fronts — everything, everywhere, all at once.[^1]

I have discussed this initiative with product coordinator Thomas Gjerulff who has added it to the agenda for the coordination group meeting on Monday, 14 August 2023. Please await the outcome of that meeting before acting on this PR.

## How
By adding some policies in the `chrome_install.sh`, I have configured Chrome to use Ecosia as the default search provider. You can read about the policies in the [Chrome Enterprise policy list](https://chromeenterprise.google/policies/atomic-groups/#DefaultSearchProvider).

I considered another approach where the [Ecosia extension](https://chrome.google.com/webstore/detail/ecosia-the-search-engine/eedlgdlajadkbbjoobobefphmfkcchfk) is installed, which automatically configures Ecosia as the default search provider. When I experimented with that solution, I made the following observations:
- The Ecosia extension additionally changes the New Tab page. That can be good or bad depending on the users' preferences.
- Because of the way the browser is currently configured, the Ecosia extension seems to open a "welcome-to-Ecosia-page" in a new tab every time the browser is opened after being closed.
- All extensions increase the risk of a Supply Chain Cyberattack - unless it is possible to pin the version of the extension. Maybe it is possible to pin the version, I don't know. I haven't looked into that.

To me it seems more simple and transparent to just configure Ecosia as the Default Search Provider directly in the policy. That is what I choose to do.

## Testing

I have tested the `chrome_install.sh` script on a machine running Ubuntu 22.10. It correctly configured Ecosia as the Default Search Provider in Chrome.

To test the changes on an OS2borgerPC, do the following:
1. Close Chrome
1. Run `chrome_install.sh`
1. Open Chrome
1. Insert non-URL text in the address bar in Chrome (i.e. "iPhone") and press <kbd>enter</kbd>
1. Verify that the search result is provided by Ecosia (URL begins with https://www.ecosia.org or https://ecosia.org)

[^1]: https://press.un.org/en/2023/sgsm21730.doc.htm 